### PR TITLE
Handle empty nicolive statistics payload

### DIFF
--- a/platforms/nicolive/src/model.rs
+++ b/platforms/nicolive/src/model.rs
@@ -109,8 +109,8 @@ pub struct WatchMessageMessageServer {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WatchMessageStatistics {
-    pub viewers: i32,
-    pub comments: i32,
+    pub viewers: Option<i32>,
+    pub comments: Option<i32>,
     pub ad_points: Option<i32>,
 }
 


### PR DESCRIPTION
## Summary
- Treat nicolive watch statistics counters as optional so empty statistics payloads deserialize successfully
- Keep adPoints consistent with the other optional statistics fields

## Verification
- cargo fmt --check -p iori-nicolive
- cargo check -p iori-nicolive (fails on existing tokio::select! feature configuration in platforms/nicolive/src/source.rs)