### PR TITLE
fix(iori-hls): keep EXT-X-KEY sticky across segments

### DIFF
--- a/crates/iori-hls/src/parse.rs
+++ b/crates/iori-hls/src/parse.rs
@@ -88,7 +88,6 @@ pub fn parse_playlist_res(input: &[u8]) -> Result<Playlist, M3u8ParseError> {
 
                 pending_inf = None;
                 pending_byterange = None;
-                current_key = None;
             }
             _ => {}
         }


### PR DESCRIPTION
In HLS, `#EXT-X-KEY` applies to all subsequent segments until overridden by a new key tag. The new parser was incorrectly resetting `current_key` to `None` after each segment URI, causing every segment after the first to have no key, producing a mismatch warning against the old m3u8-rs parser on every playlist fetch.